### PR TITLE
Hide sec3 nav arrow, & display global arrow while sec3 is incomplete

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,8 @@
                     <img src="assets/images/boobaloo-Compass-300px.png" height=200px width=200px id="compass">
                     <p text="center">They’re searching the microscopic world for answers to our biggest problems, but it’s hard to know where to start. That’s why many use computer simulations to point them in the right direction, just as explorers rely on maps to find their way.</p> 
                     <strong text="center">Finding answers is tough, and without more computers, doing scientific research can be a bit like exploring with an incomplete map</strong>
-                    <a href="#section3b" class="section3Arrow"> <img src="assets/images/down-arrow.png" height=48px width=48px id="arrow3"></a>
+                    <!-- Arrow temporarily removed by SF while sec3 subsections are incomplete and hidden -->
+                    <!-- <a href="#section3b" class="section3Arrow"> <img src="assets/images/down-arrow.png" height=48px width=48px id="arrow3"></a> -->
                 </div>
                 
             

--- a/script.js
+++ b/script.js
@@ -61,7 +61,7 @@ function changeCarouselColor(e) {
                     carButtons[i].style.backgroundColor = 'transparent';
                 }
                 // change color of main arrow
-                if (currentHash != '#section3') {
+                if (currentHash != '#section3temp') {  // temporarily changed from #section3 to #section3temp, to enable arrow while sec3 subsections are hidden and incomplete.
                     mainDownArrow.src = "assets/images/circular-down-arrow-button_white.png"
                     mainDownArrow.style.display = 'block';
                 } else {


### PR DESCRIPTION
Since I won't have time to complete section 3 before release, I think it makes sense to show the global navigational arrow on slide 3a, and hide the slide 3 subsection-navigational arrow.  Once we have a chance to complete slide 3, we can easily reconfigure this feature.  Changes have been documented in code comments.